### PR TITLE
Add gravity and fix movement bug.

### DIFF
--- a/Scripts/Player1.gd
+++ b/Scripts/Player1.gd
@@ -3,6 +3,7 @@ extends KinematicBody
 export(float) var speed = 5.5
 export(float) var jogging_speed = 2.0
 
+const gravity = 9.8 # metres / second / second
 const friction = 0.98 # each frame the velocity decreases by 2%
 const vertical_axis = Vector3(0, 1, 0)
 const ten_degrees = 10 * TAU/360
@@ -18,7 +19,14 @@ func _input(event):
     var movement = Vector3()
     
     # forward direction is the players current direction
-    var forward = velocity.normalized()
+    var forward = velocity
+    
+    # Running should only move us horizontally even if we are currently
+    # moving upwards or downwards.
+    forward.y = 0
+    
+    forward = forward.normalized()
+    
     # each key is rotated further from the forward direction
     # to move directly forward, the player can alternate left_1 and right_1
     if event.is_action_pressed("move_left_1"):
@@ -45,13 +53,17 @@ func _input(event):
 
 func _physics_process(delta):
     
-    # friction with minimum speed (jogging speed)
+    # Friction with minimum speed (jogging speed)
+    # Friction applies to vertical velocity too. Depending on the strength of
+    # gravity we will reach a terminal velocity, not sure what it will be.
     var jogging_velocity = velocity.normalized() * jogging_speed
     var velocity_after_friction = velocity * friction
     if jogging_velocity.length() > velocity_after_friction.length():
         velocity = jogging_velocity
     else:
         velocity = velocity_after_friction
+    
+    velocity.y -= gravity * delta
     
     velocity = move_and_slide(velocity, vertical_axis)
     


### PR DESCRIPTION
Due to a quirk in the movement implementation, when the player was moving vertically, the movement would cause more vertical velocity, which was strange. Movement now has the Y component set to 0.